### PR TITLE
Update Ubuntu to use Python 3.8 ASAA-2223

### DIFF
--- a/quickstart-cfn-tools.source
+++ b/quickstart-cfn-tools.source
@@ -130,7 +130,7 @@ function qs_get-osversion () {
 function qs_get-python-path() {
     local __return=$1
     # Set PYTHON_EXECUTEABLE to default python version
-    if command -v python3.9 > /dev/null 2>&1; then
+    if command -v python3.8 > /dev/null 2>&1; then
        PYTHON_EXECUTEABLE=$(which python3.9)
     elif command -v python3 > /dev/null 2>&1; then
        PYTHON_EXECUTEABLE=$(which python3)
@@ -289,8 +289,8 @@ function qs_aws-cfn-bootstrap() {
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
 	sudo apt install python3 python3-pip -y
 	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
-	#sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo pip3.8 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	#sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "16.04" ]; then
         echo "Warning: Support for this OS Version is deprecated - Consider upgrading to 20.04"
         sudo apt-get update -y
@@ -299,8 +299,8 @@ function qs_aws-cfn-bootstrap() {
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
 	sudo apt install python3 python3-pip -y
 	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
-	#sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo pip3.8 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	#sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "18.04" ]; then
         echo "Warning: Support for this OS Version is deprecated - Consider upgrading to 20.04"
         sudo apt-get update -y
@@ -308,8 +308,8 @@ function qs_aws-cfn-bootstrap() {
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
         sudo apt install python3 python3-pip -y
 	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
-	#sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo pip3.8 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	#sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "20.04" ]; then
         sudo apt-get update -y
         #apt-get install python2.7 -y
@@ -318,8 +318,8 @@ function qs_aws-cfn-bootstrap() {
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
         sudo apt install python3 python3-pip -y
 	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
-	#sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo pip3.8 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	#sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "rhel" ]; then
         yum update -y
         pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz

--- a/quickstart-cfn-tools.source
+++ b/quickstart-cfn-tools.source
@@ -308,7 +308,7 @@ function qs_aws-cfn-bootstrap() {
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
         sudo apt install python3 python3-pip -y
 	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
-	sudo pip3.8 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	#sudo pip3.8 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
 	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "20.04" ]; then
         sudo apt-get update -y

--- a/quickstart-cfn-tools.source
+++ b/quickstart-cfn-tools.source
@@ -131,7 +131,7 @@ function qs_get-python-path() {
     local __return=$1
     # Set PYTHON_EXECUTEABLE to default python version
     if command -v python3.8 > /dev/null 2>&1; then
-       PYTHON_EXECUTEABLE=$(which python3.9)
+       PYTHON_EXECUTEABLE=$(which python3.8)
     elif command -v python3 > /dev/null 2>&1; then
        PYTHON_EXECUTEABLE=$(which python3)
     else

--- a/quickstart-cfn-tools.source
+++ b/quickstart-cfn-tools.source
@@ -290,7 +290,7 @@ function qs_aws-cfn-bootstrap() {
 	sudo apt install python3 python3-pip -y
 	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
 	sudo pip3.8 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-	#sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "16.04" ]; then
         echo "Warning: Support for this OS Version is deprecated - Consider upgrading to 20.04"
         sudo apt-get update -y
@@ -300,7 +300,7 @@ function qs_aws-cfn-bootstrap() {
 	sudo apt install python3 python3-pip -y
 	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
 	sudo pip3.8 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-	#sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "18.04" ]; then
         echo "Warning: Support for this OS Version is deprecated - Consider upgrading to 20.04"
         sudo apt-get update -y
@@ -309,7 +309,7 @@ function qs_aws-cfn-bootstrap() {
         sudo apt install python3 python3-pip -y
 	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
 	sudo pip3.8 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-	#sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "20.04" ]; then
         sudo apt-get update -y
         #apt-get install python2.7 -y
@@ -319,7 +319,7 @@ function qs_aws-cfn-bootstrap() {
         sudo apt install python3 python3-pip -y
 	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
 	sudo pip3.8 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-	#sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "rhel" ]; then
         yum update -y
         pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz

--- a/quickstart-cfn-tools.source
+++ b/quickstart-cfn-tools.source
@@ -287,23 +287,29 @@ function qs_aws-cfn-bootstrap() {
 	# Ubuntu 14.04 and 16.04 are running python3.9 as a secondary install as the default version is too old
         #sudo apt-get install python2.7 python-pip -y
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-	#sudo apt install python3 python3-pip -y
-	sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo apt install python3 python3-pip -y
+	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
+	#sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "16.04" ]; then
         echo "Warning: Support for this OS Version is deprecated - Consider upgrading to 20.04"
         sudo apt-get update -y
 	# Ubuntu 14.04 and 16.04 are running python3.9 as a secondary install as the default version is too old
         #sudo apt-get install python2.7 python-pip -y
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-	#sudo apt install python3 python3-pip -y
-	sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo apt install python3 python3-pip -y
+	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
+	#sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "18.04" ]; then
         echo "Warning: Support for this OS Version is deprecated - Consider upgrading to 20.04"
         sudo apt-get update -y
         #sudo apt-get install python-pip -y
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
         sudo apt install python3 python3-pip -y
-	sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
+	#sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "20.04" ]; then
         sudo apt-get update -y
         #apt-get install python2.7 -y
@@ -311,7 +317,9 @@ function qs_aws-cfn-bootstrap() {
         #sudo python2.7 get-pip.py
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
         sudo apt install python3 python3-pip -y
-	sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
+	#sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "rhel" ]; then
         yum update -y
         pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz

--- a/quickstart-cfn-tools.source
+++ b/quickstart-cfn-tools.source
@@ -130,7 +130,9 @@ function qs_get-osversion () {
 function qs_get-python-path() {
     local __return=$1
     # Set PYTHON_EXECUTEABLE to default python version
-    if command -v python3 > /dev/null 2>&1; then
+    if command -v python3.9 > /dev/null 2>&1; then
+       PYTHON_EXECUTEABLE=$(which python3.9)
+    elif command -v python3 > /dev/null 2>&1; then
        PYTHON_EXECUTEABLE=$(which python3)
     else
        PYTHON_EXECUTEABLE=$(which python)
@@ -282,17 +284,19 @@ function qs_aws-cfn-bootstrap() {
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "14.04" ]; then
         echo "Warning: Support for this OS Version is deprecated - Consider upgrading to 20.04"
         sudo apt-get update -y
+	# Ubuntu 14.04 and 16.04 are running python3.9 as a secondary install as the default version is too old
         #sudo apt-get install python2.7 python-pip -y
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-	sudo apt install python3 python3-pip -y
-	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	#sudo apt install python3 python3-pip -y
+	sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "16.04" ]; then
         echo "Warning: Support for this OS Version is deprecated - Consider upgrading to 20.04"
         sudo apt-get update -y
+	# Ubuntu 14.04 and 16.04 are running python3.9 as a secondary install as the default version is too old
         #sudo apt-get install python2.7 python-pip -y
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-	sudo apt install python3 python3-pip -y
-	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	#sudo apt install python3 python3-pip -y
+	sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "18.04" ]; then
         echo "Warning: Support for this OS Version is deprecated - Consider upgrading to 20.04"
         sudo apt-get update -y

--- a/quickstart-cfn-tools.source
+++ b/quickstart-cfn-tools.source
@@ -303,7 +303,7 @@ function qs_aws-cfn-bootstrap() {
         #sudo apt-get install python-pip -y
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
         sudo apt install python3 python3-pip -y
-	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "20.04" ]; then
         sudo apt-get update -y
         #apt-get install python2.7 -y
@@ -311,7 +311,7 @@ function qs_aws-cfn-bootstrap() {
         #sudo python2.7 get-pip.py
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
         sudo apt install python3 python3-pip -y
-	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+	sudo pip3.9 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "rhel" ]; then
         yum update -y
         pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz


### PR DESCRIPTION
# Pull Request

To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] New/updated Container Image
* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [X] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [ ] Yes (backward compatible)
* [X] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
- Ubuntu 14/16 use too old of a default python to support AWS's boto3 (Python 3.4.3). Python 3.9 is too new to support AWS's https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz 
- This PR needs to be done in conjunction with https://github.com/gdcorp-engineering/golden-images/pull/229 
-


