### PR TITLE
Disallow pystache 0.6.0 on py2.7

### DIFF
--- a/quickstart-cfn-tools.source
+++ b/quickstart-cfn-tools.source
@@ -286,6 +286,7 @@ function qs_aws-cfn-bootstrap() {
         sudo apt-get update -y
 	# Ubuntu 14.04 and 16.04 are running python3.9 as a secondary install as the default version is too old
         #sudo apt-get install python2.7 python-pip -y
+        #sudo pip2 install "pystache>=0.4.0,<0.6.0"
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
 	sudo apt install python3 python3-pip -y
 	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
@@ -296,6 +297,7 @@ function qs_aws-cfn-bootstrap() {
         sudo apt-get update -y
 	# Ubuntu 14.04 and 16.04 are running python3.9 as a secondary install as the default version is too old
         #sudo apt-get install python2.7 python-pip -y
+        #sudo pip2 install "pystache>=0.4.0,<0.6.0"
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
 	sudo apt install python3 python3-pip -y
 	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
@@ -305,6 +307,7 @@ function qs_aws-cfn-bootstrap() {
         echo "Warning: Support for this OS Version is deprecated - Consider upgrading to 20.04"
         sudo apt-get update -y
         #sudo apt-get install python-pip -y
+        #sudo pip2 install "pystache>=0.4.0,<0.6.0"
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
         sudo apt install python3 python3-pip -y
 	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
@@ -315,6 +318,7 @@ function qs_aws-cfn-bootstrap() {
         #apt-get install python2.7 -y
         #curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
         #sudo python2.7 get-pip.py
+        #sudo pip2 install "pystache>=0.4.0,<0.6.0"
         #sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
         sudo apt install python3 python3-pip -y
 	#Throws "AttributeError: 'HTMLParser' object has no attribute 'unescape'", this has been depreciated since python3.4, removed in 3.9. Should be fixed by AWS at some point and we'll need to switch to 3.9
@@ -322,16 +326,20 @@ function qs_aws-cfn-bootstrap() {
 	sudo pip3 install  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "rhel" ]; then
         yum update -y
+        pip install "pystache>=0.4.0,<0.6.0"
         pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "centos" ]; then
         yum update -y
         qs_bootstrap_pip
+        pip install "pystache>=0.4.0,<0.6.0"
         pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "fedora" ]; then
+        pip install "pystache>=0.4.0,<0.6.0"
         pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "sles" ]; then
         zypper -n refresh && zypper -n update
         zypper -n install python2-pip
+        pip2.7 install "pystache>=0.4.0,<0.6.0"
         pip2.7 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
         echo "[WARNING] not implemeneted"
     else


### PR DESCRIPTION
 https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz has
dependencies = ['python-daemon>=2.1,<2.2', 'pystache>=0.4.0', 'docutils', 'setuptools<=57.5.0']
and pystache is no good for 2.7. since it tries to fulfill it with 0.6.0